### PR TITLE
Fix Garbled message in non-English Windows

### DIFF
--- a/lib/grammars/java.js
+++ b/lib/grammars/java.js
@@ -20,7 +20,7 @@ export const Java = {
       const classPackages = GrammarUtils.Java.getClassPackage(context)
       const sourcePath = GrammarUtils.Java.getProjectPath(context)
       if (windows) {
-        return [`/c javac -Xlint ${context.filename} && java ${className}`]
+        return [`/c javac ーJ-Dfile.encoding=UTF-8 -Xlint ${context.filename} && java -Dfile.encoding=UTF-8 ${className}`]
       } else {
         return [
           "-c",


### PR DESCRIPTION
Quick fix for the issue #1166, Java build in non-English editions of Window will result garbled message, stdout and stderr displayed.
This fix would have further issue: if user's final target deployment would have different encodings from all-UTF-8 setup, (such as "normal" Windows cmd.exe, they normally have ANSI encodings for average users) so testing and evaluating might become more difficult.